### PR TITLE
[WIP] Add statsd compliant output

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -101,6 +101,25 @@ begin
     # else
     #   puts 'status err haproxy is not running!'
     # end
+  when "statsd"
+    if pidof
+      status=unixsock("show stat")
+      line=status[0].gsub!(/# /,'')
+      HEADERS=line.split(',')[0..-2]
+      CONFIG_INSTANCE_FILE = '/etc/haproxy/haproxyctl/instance-name'
+      CONFIG_INSTANCE_DEFAULT_NAME = 'testing.localhost'
+      INSTANCE = File.read(CONFIG_INSTANCE_FILE).chomp if File.exists?(CONFIG_INSTANCE_FILE)
+      INSTANCE ||= CONFIG_INSTANCE_DEFAULT_NAME
+      status.shift
+      status.each do |line|
+        if not line.chomp == ""
+          stats=Hash[HEADERS.zip(line.split(','))]
+          %w(scur smax ereq econ rate).each do |statname|
+            puts "HAProxy.#{INSTANCE}.#{stats['pxname']}.#{stats['svname']}.#{statname}:#{stats[statname]}|g"
+          end
+        end
+      end
+    end
   when 'show health'
     status = unixsock('show stat')
     status.each do |line|


### PR DESCRIPTION
Add statsd compatible status output, such as:

    HAProxy.playground.lb1.nginxphpapp_php_app_servers.nginxphpapp1.scur:0|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.nginxphpapp1.smax:21|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.nginxphpapp1.ereq:|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.nginxphpapp1.econ:0|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.nginxphpapp1.rate:0|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.BACKEND.scur:0|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.BACKEND.smax:21|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.BACKEND.ereq:|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.BACKEND.econ:0|g
    HAProxy.playground.lb1.nginxphpapp_php_app_servers.BACKEND.rate:0|g
    HAProxy.playground.lb1.http-in.FRONTEND.scur:0|g
    HAProxy.playground.lb1.http-in.FRONTEND.smax:21|g
    HAProxy.playground.lb1.http-in.FRONTEND.ereq:5834|g
    HAProxy.playground.lb1.http-in.FRONTEND.econ:|g
    HAProxy.playground.lb1.http-in.FRONTEND.rate:0|g

This output can then easily be forwarded to statsd, i.e. in Bash:
```
# haproxyctl statsd | while read metric; do echo "$metric" >/dev/udp/stats.server.tld/8125; done
```
Surely, this is not very well generalized and specifically implemented for our very use-case. Nevertheless it works and is already presenting first test graphs: https://metrics.librato.com/instruments/33206769

It is worth knowing that this patch introduces the new configuration file /etc/haproxy/stack that contains the name of the Opsworks stack in which this instance ins running - it is used for naming the metrics (in the above example: playground).
